### PR TITLE
Updates for current varnish-cache master & current autoconf

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,9 +1,9 @@
-AC_PREREQ(2.68)
+AC_PREREQ([2.69])
 AC_COPYRIGHT([Copyright (c) 2013-2015 Kenneth Shaw, 2018 UPLEX])
-AC_INIT([libvmod-dns], [trunk])
+AC_INIT([libvmod-dns],[trunk])
 AC_CONFIG_MACRO_DIR([m4])
 AC_CONFIG_AUX_DIR([build-aux])
-AC_CONFIG_HEADER([config.h])
+AC_CONFIG_HEADERS([config.h])
 
 AM_INIT_AUTOMAKE([1.12 -Wall -Werror foreign parallel-tests])
 AM_SILENT_RULES([yes])

--- a/configure.ac
+++ b/configure.ac
@@ -17,7 +17,7 @@ AC_ARG_WITH([rst2man],
 		[--with-rst2man=PATH],
 		[Location of rst2man (auto)]),
 	[RST2MAN="$withval"],
-	AC_CHECK_PROGS(RST2MAN, [rst2man rst2man.py], []))
+	[AC_CHECK_PROGS(RST2MAN, [rst2man rst2man.py], [])])
 
 VARNISH_PREREQ([5.2.0])
 VARNISH_VMODS([dns])

--- a/src/vmod_dns.c
+++ b/src/vmod_dns.c
@@ -45,7 +45,9 @@
 
 #include "vcc_dns_if.h"
 
-#define VSTR(s)(&(struct strands){.n=1,.p=(const char *[1]){s}})
+#ifndef TOSTRAND
+#define TOSTRAND(s)(&(struct strands){.n=1,.p=(const char *[1]){s}})
+#endif
 
 VCL_STRING
 vmod_resolve(VRT_CTX, VCL_STRING hostname)
@@ -84,7 +86,7 @@ vmod_resolve(VRT_CTX, VCL_STRING hostname)
 
 	char p[len];
 	r = VRT_STRANDS_string(ctx,
-	    VSTR(inet_ntop(res->ai_family, addr, p, len)));
+	    TOSTRAND(inet_ntop(res->ai_family, addr, p, len)));
 
 	freeaddrinfo(res);
 	return (r);
@@ -104,7 +106,7 @@ vmod_rresolve(VRT_CTX, VCL_STRING hostname)
 
 	if (!getnameinfo(res->ai_addr, res->ai_addrlen, node,
 	    sizeof(node), NULL, 0, 0))
-		p = VRT_STRANDS_string(ctx, VSTR(node));
+		p = VRT_STRANDS_string(ctx, TOSTRAND(node));
 
 	freeaddrinfo(res);
 	return (p);
@@ -157,7 +159,7 @@ valid_ip(VRT_CTX, const struct sockaddr *sa, const socklen_t sl)
 		if (res->ai_family == sa->sa_family &&
 		    res->ai_addrlen == sl &&
 		    cmp_addr(res->ai_addr, sa) == 0) {
-			r = VRT_STRANDS_string(ctx, VSTR(node));
+			r = VRT_STRANDS_string(ctx, TOSTRAND(node));
 			break;
 		}
 	}


### PR DESCRIPTION
* Use the `TOSTRAND()` macro
* Fix `configure.ac` syntax
* and renovate it