### PR TITLE
Switch to WS_Copy, adjust to Varnish-Cache as of 7.7

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ stamp-h1
 
 vcc_*_if.[ch]
 vmod_*.rst
+vmod_vcs_version.txt
 
 # man
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -11,6 +11,10 @@ nodist_libvmod_dns_la_SOURCES = \
 	vcc_dns_if.c \
 	vcc_dns_if.h
 
+DISTCLEANFILES = vmod_vcs_version.txt
+
+vmod_vcs_version.txt: $(nodist_libvmod_dns_la_SOURCES)
+
 @BUILD_VMOD_DNS@
 
 # Test suite
@@ -44,3 +48,6 @@ dist_man_MANS = \
 
 .rst.1:
 	$(AM_V_GEN) $(RST2MAN) $< $@
+
+EXTRA_DIST = \
+	vmod_vcs_version.txt


### PR DESCRIPTION
The first commit switches to `WS_Copy()` to ensure a copy is made even if Varnish-Cache switches to avoiding copies.
The second commit makes the necessary adjustments to support VMOD version information in Varnish-Cache 7.7 and later.